### PR TITLE
refactor: new policy for variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,15 @@ ansible-playbook jobs/configure.yml
 ## Contributing
 
 Please use ansible-lint before submitting a PR.
+
+### Variables management
+
+It can be difficult in ansible to understand where a variable is defined,
+and where it is used.
+
+In this repository we will try to follow the following rules:
+* a role declares all the variables it uses in `defaults/main.yml`.
+  This is the interface of the role.
+* externally variables use a prefix using role name (eg: for sshd role, use `sshd_` prefix.)
+  * inside the role, the prefix is not used
+* secret always add the prefix `vault_` and must be encrypted with ansible-vault

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -1,8 +1,13 @@
 ---
-base_motd_warning: Unauthorized access to this system is forbidden and will be prosecuted.
+motd_warning: |
+  {{ base_motd_warning
+  | default('Unauthorized access to this system is forbidden and will be prosecuted.') }}
 
-base_ntp_servers: []
-base_ntp_fallback_servers:
+ntp_servers: "{{ base_ntp_servers | default([]) }}"
+
+
+ntp_fallback_servers: "{{base_ntp_fallback_servers | default(_default_ntp_servers) }}"
+_default_ntp_servers:
   - 0.pool.ntp.org
   - 1.pool.ntp.org
   - 2.pool.ntp.org
@@ -11,82 +16,83 @@ base_ntp_fallback_servers:
 # Unattended-Upgrade::Origins-Pattern
 # Automatically upgrade packages from these origin patterns
 # e.g.: 'o=Debian,a=stable', 'o=Debian,a=stable-updates'
-base_unattended_origins_patterns:
+unattended_origins_patterns: "{{ base_unattended_origins_patterns | default(_unattended_origins_patterns) }}"
+_unattended_origins_patterns:
   - origin=Debian,codename={{ ansible_distribution_release }},label=Debian-Security
 
 # Unattended-Upgrade::Package-Blacklist
 # List of packages to not update
-base_unattended_package_blacklist: []
+unattended_package_blacklist: "{{ base_unattended_package_blacklist | default([]) }}"
 
 # Unattended-Upgrade::AutoFixInterruptedDpkg
 # On a unclean dpkg exit unattended-upgrades will run
 #   dpkg --force-confold --configure -a
 # The default is true, to ensure updates keep getting installed
-base_unattended_autofix_interrupted_dpkg: true
+unattended_autofix_interrupted_dpkg: "{{ base_unattended_autofix_interrupted_dpkg | default(true) }}"
 
 # Unattended-Upgrade::MinimalSteps
 # Split the upgrade into the smallest possible chunks so that
 # they can be interrupted with SIGUSR1. This makes the upgrade
 # a bit slower but it has the benefit that shutdown while a upgrade
 # is running is possible (with a small delay)
-base_unattended_minimal_steps: false
+unattended_minimal_steps: "{{ base_unattended_minimal_steps | default(false) }}"
 
 # Unattended-Upgrade::InstallOnShutdown
 # Install all unattended-upgrades when the machine is shuting down
 # instead of doing it in the background while the machine is running
 # This will (obviously) make shutdown slower
-base_unattended_install_on_shutdown: false
+unattended_install_on_shutdown: "{{ base_unattended_install_on_shutdown | default(false) }}"
 
 # Unattended-Upgrade::Mail
 # Send email to this address for problems or packages upgrades
 # If empty or unset then no email is sent, make sure that you
 # have a working mail setup on your system. A package that provides
 # 'mailx' must be installed.
-base_unattended_mail: false
+unattended_mail: "{{ base_unattended_mail | default(false) }}"
 
 # Unattended-Upgrade::MailOnlyOnError
 # Set this value to "true" to get emails only on errors. Default
 # is to always send a mail if Unattended-Upgrade::Mail is set
-base_unattended_mail_only_on_error: false
+unattended_mail_only_on_error: "{{ base_unattended_mail_only_on_error | default(false) }}"
 
 # Unattended-Upgrade::Remove-Unused-Dependencies
 # Do automatic removal of new unused dependencies after the upgrade
 # (equivalent to apt-get autoremove)
-base_unattended_remove_unused_dependencies: false
+unattended_remove_unused_dependencies: "{{ base_unattended_remove_unused_dependencies | default(false) }}"
 
 # Unattended-Upgrade::Automatic-Reboot
 # Automatically reboot *WITHOUT CONFIRMATION* if a
 # the file /var/run/reboot-required is found after the upgrade
-base_unattended_automatic_reboot: false
+unattended_automatic_reboot: "{{ base_unattended_automatic_reboot | default(false) }}"
 
 # Unattended-Upgrade::Automatic-Reboot-Time
 # If automatic reboot is enabled and needed, reboot at the specific
 # time instead of immediately
-base_unattended_automatic_reboot_time: false
+unattended_automatic_reboot_time: "{{ base_unattended_automatic_reboot_time | default(false) }}"
 
 # Unattended-Upgrade::IgnoreAppsRequireRestart
 # Do upgrade application even if it requires restart after upgrade
 # I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file
-base_unattended_ignore_apps_require_restart: false
+unattended_ignore_apps_require_restart: "{{ base_unattended_ignore_apps_require_restart | default(false) }}"
 
 ### APT::Periodic configuration
 # Snatched from /usr/lib/apt/apt.systemd.daily
 
 # APT::Periodic::Update-Package-Lists "0";
 # - Do "apt-get update" automatically every n-days (0=disable)
-base_unattended_update_package_list: 0
+unattended_update_package_list: "{{ base_unattended_update_package_list | default(0) }}"
 
 # APT::Periodic::Download-Upgradeable-Packages "0";
 # - Do "apt-get upgrade --download-only" every n-days (0=disable)
-base_unattended_download_upgradeable: 0
+unattended_download_upgradeable: "{{ base_unattended_download_upgradeable | default(0) }}"
 
 # APT::Periodic::AutocleanInterval "0";
 # - Do "apt-get autoclean" every n-days (0=disable)
-base_unattended_autoclean_interval: 0
+unattended_autoclean_interval: "{{ base_unattended_autoclean_interval | default(0) }}"
 
 # APT::Periodic::CleanInterval "0";
 # - Do "apt-get clean" every n-days (0=disable)
-base_unattended_clean_interval: 0
+unattended_clean_interval: "{{ base_unattended_clean_interval | default(0) }}"
 
 # APT::Periodic::Verbose "0";
 # - Send report mail to root
@@ -94,7 +100,7 @@ base_unattended_clean_interval: 0
 #     1:  progress report       (actually any string)
 #     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
 #     3:  + trace on
-base_unattended_verbose: 0
+unattended_verbose: "{{ base_unattended_verbose | default(0) }}"
 
 # APT::Periodic::RandomSleep
 # When the apt job starts, it will sleep for a random period between 0
@@ -103,7 +109,7 @@ base_unattended_verbose: 0
 # minutes (1800 seconds) so that the mirror servers are not crushed by
 # everyone running their updates all at the same time
 # Kept undefined to allow default (1800)
-base_unattended_random_sleep:
+unattended_random_sleep: base_unattended_random_sleep
 
 # Add with other base variables
-base_timezone: UTC
+timezone: "{{ base_timezone | default(UTC) }}"

--- a/roles/base/tasks/time.yml
+++ b/roles/base/tasks/time.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Set timezone"
   community.general.timezone:
-    name: "{{ base_timezone }}"
+    name: "{{ timezone }}"
   notify:
     - "Reload systemd"
     - "Restart systemd-timesyncd"

--- a/roles/base/templates/apt-auto-upgrades
+++ b/roles/base/templates/apt-auto-upgrades
@@ -4,29 +4,29 @@
 APT::Periodic::Unattended-Upgrade "1";
 
 // Do "apt-get update" automatically every n-days (0=disable)
-APT::Periodic::Update-Package-Lists "{{ base_unattended_update_package_list }}";
+APT::Periodic::Update-Package-Lists "{{ unattended_update_package_list }}";
 
 // Do "apt-get upgrade --download-only" every n-days (0=disable)
-APT::Periodic::Download-Upgradeable-Packages "{{ base_unattended_download_upgradeable }}";
+APT::Periodic::Download-Upgradeable-Packages "{{ unattended_download_upgradeable }}";
 
 // Do "apt-get autoclean" every n-days (0=disable)
-APT::Periodic::AutocleanInterval "{{ base_unattended_autoclean_interval }}";
+APT::Periodic::AutocleanInterval "{{ unattended_autoclean_interval }}";
 
 // Do "apt-get clean" every n-days (0=disable)
-APT::Periodic::CleanInterval "{{ base_unattended_clean_interval }}";
+APT::Periodic::CleanInterval "{{ unattended_clean_interval }}";
 
 // Send report mail to root
 // 0:  no report
 // 1:  progress report
 // 2:  + command outputs (remove -qq, remove 2>/dev/null, add -d)
 // 3:  + trace on
-APT::Periodic::Verbose "{{ base_unattended_verbose }}";
+APT::Periodic::Verbose "{{ unattended_verbose }}";
 
-{% if base_unattended_random_sleep %}
+{% if unattended_random_sleep %}
 // When the apt job starts, it will sleep for a random period between 0
 // and APT::Periodic::RandomSleep seconds
 // The default value is "1800" so that the script will stall for up to 30
 // minutes (1800 seconds) so that the mirror servers are not crushed by
 // everyone running their updates all at the same time
-APT::Periodic::RandomSleep "{{ base_unattended_random_sleep }}";
+APT::Periodic::RandomSleep "{{ unattended_random_sleep }}";
 {% endif %}

--- a/roles/base/templates/apt-unattended-upgrades
+++ b/roles/base/templates/apt-unattended-upgrades
@@ -2,17 +2,17 @@
 
 // Unattended-Upgrade::Origins-Pattern controls which packages are upgraded.
 Unattended-Upgrade::Origins-Pattern {
-{% for origin in base_unattended_origins_patterns %}    "{{ origin }}";
+{% for origin in unattended_origins_patterns %}    "{{ origin }}";
 {% endfor %}
 };
 
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
-{% for package in base_unattended_package_blacklist %}      "{{package}}";
+{% for package in unattended_package_blacklist %}      "{{package}}";
 {% endfor %}
 };
 
-{% if not base_unattended_autofix_interrupted_dpkg -%}
+{% if not unattended_autofix_interrupted_dpkg -%}
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
@@ -20,7 +20,7 @@ Unattended-Upgrade::Package-Blacklist {
 Unattended-Upgrade::AutoFixInterruptedDpkg "false";
 {% endif %}
 
-{% if base_unattended_minimal_steps -%}
+{% if unattended_minimal_steps -%}
 // Split the upgrade into the smallest possible chunks so that
 // they can be interrupted with SIGUSR1. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
@@ -28,47 +28,47 @@ Unattended-Upgrade::AutoFixInterruptedDpkg "false";
 Unattended-Upgrade::MinimalSteps "true";
 {% endif %}
 
-{% if base_unattended_install_on_shutdown -%}
+{% if unattended_install_on_shutdown -%}
 // Install all unattended-upgrades when the machine is shuting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
 Unattended-Upgrade::InstallOnShutdown "true";
 {% endif %}
 
-{% if base_unattended_mail -%}
+{% if unattended_mail -%}
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides
 // 'mailx' must be installed.
-Unattended-Upgrade::Mail "{{ base_unattended_mail }}";
+Unattended-Upgrade::Mail "{{ unattended_mail }}";
 {% endif %}
 
-{% if base_unattended_mail_only_on_error -%}
+{% if unattended_mail_only_on_error -%}
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set
 Unattended-Upgrade::MailOnlyOnError "true";
 {% endif %}
 
-{% if base_unattended_remove_unused_dependencies -%}
+{% if unattended_remove_unused_dependencies -%}
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
 {% endif %}
 
-{% if base_unattended_automatic_reboot -%}
+{% if unattended_automatic_reboot -%}
 // Automatically reboot *WITHOUT CONFIRMATION* if a
 // the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "true";
 {% endif %}
 
-{% if base_unattended_automatic_reboot_time -%}
+{% if unattended_automatic_reboot_time -%}
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
 Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
 {% endif %}
 
-{% if base_unattended_ignore_apps_require_restart -%}
+{% if unattended_ignore_apps_require_restart -%}
 // Do upgrade application even if it requires restart after upgrade
 // I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file
 Unattended-Upgrade::IgnoreAppsRequireRestart "true";

--- a/roles/base/templates/motd
+++ b/roles/base/templates/motd
@@ -4,6 +4,6 @@
 {% endif %}
   [1;37mHostname[0m	: {{ inventory_hostname }}.{{ host_domain }}
 
-{% if base_motd_warning %}  [1;31mWARNING[0m: {{base_motd_warning }}
+{% if motd_warning %}  [1;31mWARNING[0m: {{ motd_warning }}
 {% endif %}
 [0m

--- a/roles/base/templates/timesyncd.conf
+++ b/roles/base/templates/timesyncd.conf
@@ -14,7 +14,7 @@
 # {{ ansible_managed }}
 
 [Time]
-{% if base_ntp_servers -%}
-NTP={{ base_ntp_servers | join(' ') }}
+{% if ntp_servers -%}
+NTP={{ ntp_servers | join(' ') }}
 {% endif -%}
-FallbackNTP={{ base_ntp_fallback_servers | join(' ') }}
+FallbackNTP={{ ntp_fallback_servers | join(' ') }}

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # Github url
-sshd_github_url: https://github.com
+github_url: "{{ sshd_github_url | default('https://github.com') }}"
 
 # Github authorized users
-sshd_github_authorized_users: []
+github_authorized_users: "{{ sshd_github_authorized_users | default([]) }}"
 
 # Github revoked users
-sshd_github_revoked_users: []
+github_revoked_users: "{{ sshd_github_revoked_users | default([]) }}"

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Authorize ssh public keys from github for ansible operator
   ansible.posix.authorized_key:
     user: '{{ ansible_ssh_user }}'
-    key: '{{ shd_github_url }}/{{ item }}.keys'
+    key: '{{ sshd_github_url }}/{{ item }}.keys'
   with_items: '{{ github_authorized_users }}'
 
 - name: Revoke ssh public keys from github for ansible operator

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -20,12 +20,12 @@
 - name: Authorize ssh public keys from github for ansible operator
   ansible.posix.authorized_key:
     user: '{{ ansible_ssh_user }}'
-    key: '{{ sshd_github_url }}/{{ item }}.keys'
-  with_items: '{{ sshd_github_authorized_users }}'
+    key: '{{ shd_github_url }}/{{ item }}.keys'
+  with_items: '{{ github_authorized_users }}'
 
 - name: Revoke ssh public keys from github for ansible operator
   ansible.posix.authorized_key:
     user: '{{ ansible_ssh_user }}'
-    key: '{{ sshd_github_url }}/{{ item }}.keys'
+    key: '{{ github_url }}/{{ item }}.keys'
     state: absent
-  with_items: '{{ sshd_github_revoked_users }}'
+  with_items: '{{ github_revoked_users }}'

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Authorize ssh public keys from github for ansible operator
   ansible.posix.authorized_key:
     user: '{{ ansible_ssh_user }}'
-    key: '{{ sshd_github_url }}/{{ item }}.keys'
+    key: '{{ github_url }}/{{ item }}.keys'
   with_items: '{{ github_authorized_users }}'
 
 - name: Revoke ssh public keys from github for ansible operator


### PR DESCRIPTION
### What
Talking to people at etalab, they shared this pattern, to use the defaults/ variable file as the "interface" for a role.

I think it's a great idea to avoid confusions.

The proposal is then to
* always prefix variables with the role name
* in the role itself, convert variables to unprefixed names and only use that (avoid skipping a declaration)

I found it a really good idea to better track variable usage.
It's open for discussion. I made the PR because it makes the discussion more concrete.